### PR TITLE
Documentation Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,5 @@ If you make changes to requirements.txt:
 docker-compose down
 docker-compose up --build
 ```
+
+Note: The Redis version has been downgraded to 4.0.2 in the requirements.txt file.


### PR DESCRIPTION
The README was updated to reflect the downgrade of the Redis version from 7.0.0 to 4.0.2 in the requirements.txt file. This change was noted in the 'Rebuilding' section.