### PR TITLE
Documentation Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ If you prefer to run without Docker:
    ```bash
    pip install -r requirements.txt
    ```
+   ⚠️ **Note:** The following dependencies have been updated:
+   - `django-redis` from 5.4.0 to 5.4.6
+   - `redis` from 5.4.0 to 5.5.0
+
 3. Copy `.env.example` to `.env` and update the values
 4. Run migrations:
    ```bash
@@ -101,3 +105,6 @@ If you make changes to requirements.txt:
 docker-compose down
 docker-compose up --build
 ```
+⚠️ **Note:** Ensure to rebuild the Docker containers to apply the updated dependencies:
+- `django-redis` updated to 5.4.6
+- `redis` updated to 5.5.0


### PR DESCRIPTION
The dependencies 'django-redis' and 'redis' have been updated to versions 5.4.6 and 5.5.0 respectively. Update the local setup and rebuild Docker containers to apply these changes.