### PR TITLE
Documentation Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Required environment variables:
 - `DB_HOST`: Database host
 - `DB_PORT`: Database port
 - `REDIS_URL`: Redis connection URL
-- `SENTRY_DSN`: Sentry Data Source Name for error tracking (optional)
+- `SENTRY_DSN`: Sentry Data Source Name for error tracking (required if using Sentry)
 
 ## API Documentation
 


### PR DESCRIPTION
The README was updated to reflect the addition of Sentry SDK initialization in the settings. The `SENTRY_DSN` environment variable is now required if using Sentry for error tracking.