### PR TITLE
docs: Update docstring for generate_scheduler_report with new parameter

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -141,6 +141,7 @@ class CleanupService:
         Args:
             start_date (datetime): The start date for the report period
             end_date (datetime): The end date for the report period
+            limit (int): The maximum number of job history entries to include in the report. Default is 100.
 
         Returns:
             Dict[str, Any]: A dictionary containing the following report sections:


### PR DESCRIPTION
The docstring for the function 'generate_scheduler_report' in 'scheduler.py' has been updated to include the new parameter 'limit'. This parameter was added to the function signature to allow limiting the number of records in the report. The update ensures that the documentation accurately reflects the current function signature and behavior.

**Impact of the changes:**
- Ensures that developers understand the purpose and usage of the new 'limit' parameter.

**Before:**
```python
async def generate_scheduler_report(self, start_date: datetime, end_date: datetime) -> Dict[str, Any]:
    """
    Generate a comprehensive report of scheduler activities and performance metrics for a specified time period.
    """
```

**After:**
```python
async def generate_scheduler_report(self, start_date: datetime, end_date: datetime, limit: int = 100) -> Dict[str, Any]:
    """
    Generate a comprehensive report of scheduler activities and performance metrics for a specified time period.

    Parameters:
    - start_date (datetime): The start date for the report.
    - end_date (datetime): The end date for the report.
    - limit (int, optional): The maximum number of records to include in the report. Default is 100.
    """
```