### PR TITLE
docs: Update docstring for generate_scheduler_report with new parameter

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -141,6 +141,7 @@ class CleanupService:
         Args:
             start_date (datetime): The start date for the report period
             end_date (datetime): The end date for the report period
+            limit (int): The maximum number of job history entries to include in the report. Default is 100.
 
         Returns:
             Dict[str, Any]: A dictionary containing the following report sections:


### PR DESCRIPTION
The docstring for the function 'generate_scheduler_report' in 'scheduler.py' has been updated to include the new parameter 'limit'. This parameter was added to the function signature to allow limiting the number of records in the report. The update ensures that the documentation accurately reflects the current function signature and its usage, which is crucial for developers and users relying on this function.